### PR TITLE
Fix typo in PATENTS

### DIFF
--- a/PATENTS
+++ b/PATENTS
@@ -1,6 +1,6 @@
 Additional Grant of Patent Rights Version 2
 
-"Software means the ReboundJS software distributed by Facebook, Inc.
+"Software" means the ReboundJS software distributed by Facebook, Inc.
 
 Facebook, Inc. ("Facebook") hereby grants to each recipient of the Software
 ("you") a perpetual, worldwide, royalty-free, non-exclusive, irrevocable


### PR DESCRIPTION
React's PATENTS file, for example, has the closing quote.