### PR TITLE
Use requestAnimationFrame's build in high precision timestamp

### DIFF
--- a/rebound.js
+++ b/rebound.js
@@ -834,8 +834,8 @@
   var AnimationLooper = rebound.AnimationLooper = function AnimationLooper() {
     this.springSystem = null;
     var _this = this;
-    var _run = function() {
-      _this.springSystem.loop(Date.now());
+    var _run = function(timeStamp) {
+      _this.springSystem.loop(timeStamp);
     };
 
     this.run = function() {


### PR DESCRIPTION
requestAnimationFrame passes back a high.precision timestamp which is far more accurate than `Date.now()` Switch to this to improve animations smoothness and accuracy.
