### PR TITLE
Add an .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,10 @@
+docs
+browser_test
+examples
+spec
+node_modules
+.travis.yml
+bower.json
+component.json
+index.html
+rebound.min.js


### PR DESCRIPTION
Hello there 👋 - I was looking through my React Native dependencies to see what was in there and I spotted that this one has a bunch of additional files which aren't relevant when used as a library in NPM. 

Things like LICENSE, PATENTS and the README are still in, but docs/examples etc are out - which is generally the pattern I've seen.