### PR TITLE
Convert docs to JSDoc style and explicitly mark public API

### DIFF
--- a/src/BouncyConversion.js
+++ b/src/BouncyConversion.js
@@ -9,7 +9,7 @@
  * @flow
  */
 
-/*
+/**
  * Provides math for converting from Origami PopAnimation
  * config values to regular Origami tension and friction values. If you are
  * trying to replicate prototypes made with PopAnimation patches in Origami,

--- a/src/BouncyConversion.js
+++ b/src/BouncyConversion.js
@@ -9,13 +9,15 @@
  * @flow
  */
 
-// BouncyConversion provides math for converting from Origami PopAnimation
-// config values to regular Origami tension and friction values. If you are
-// trying to replicate prototypes made with PopAnimation patches in Origami,
-// then you should create your springs with
-// SpringSystem.createSpringWithBouncinessAndSpeed, which uses this Math
-// internally to create a spring to match the provided PopAnimation
-// configuration from Origami.
+/*
+ * Provides math for converting from Origami PopAnimation
+ * config values to regular Origami tension and friction values. If you are
+ * trying to replicate prototypes made with PopAnimation patches in Origami,
+ * then you should create your springs with
+ * SpringSystem.createSpringWithBouncinessAndSpeed, which uses this Math
+ * internally to create a spring to match the provided PopAnimation
+ * configuration from Origami.
+ */
 class BouncyConversion {
   bounciness: number;
   bouncyTension: number;

--- a/src/Loopers.js
+++ b/src/Loopers.js
@@ -12,11 +12,12 @@
 import type SpringSystem from './SpringSystem';
 import * as util from './util';
 
-// Loopers
-// -------
-// **AnimationLooper** plays each frame of the SpringSystem on animation
-// timing loop. This is the default type of looper for a new spring system
-// as it is the most common when developing UI.
+/**
+ * Plays each frame of the SpringSystem on animation
+ * timing loop. This is the default type of looper for a new spring system
+ * as it is the most common when developing UI.
+ * @public
+ */
 export class AnimationLooper {
   springSystem: ?SpringSystem = null;
 
@@ -29,12 +30,15 @@ export class AnimationLooper {
   }
 }
 
-// **SimulationLooper** resolves the SpringSystem to a resting state in a
-// tight and blocking loop. This is useful for synchronously generating
-// pre-recorded animations that can then be played on a timing loop later.
-// Sometimes this lead to better performance to pre-record a single spring
-// curve and use it to drive many animations; however, it can make dynamic
-// response to user input a bit trickier to implement.
+/**
+ * Resolves the SpringSystem to a resting state in a
+ * tight and blocking loop. This is useful for synchronously generating
+ * pre-recorded animations that can then be played on a timing loop later.
+ * Sometimes this lead to better performance to pre-record a single spring
+ * curve and use it to drive many animations; however, it can make dynamic
+ * response to user input a bit trickier to implement.
+ * @public
+ */
 export class SimulationLooper {
   springSystem: ?SpringSystem = null;
   timestep: number;
@@ -59,11 +63,14 @@ export class SimulationLooper {
   }
 }
 
-// **SteppingSimulationLooper** resolves the SpringSystem one step at a
-// time controlled by an outside loop. This is useful for testing and
-// verifying the behavior of a SpringSystem or if you want to control your own
-// timing loop for some reason e.g. slowing down or speeding up the
-// simulation.
+/**
+ * Resolves the SpringSystem one step at a
+ * time controlled by an outside loop. This is useful for testing and
+ * verifying the behavior of a SpringSystem or if you want to control your own
+ * timing loop for some reason e.g. slowing down or speeding up the
+ * simulation.
+ * @public
+ */
 export class SteppingSimulationLooper {
   springSystem: ?SpringSystem = null;
   timestep: number;

--- a/src/MathUtil.js
+++ b/src/MathUtil.js
@@ -11,14 +11,17 @@
 
 import * as util from './util';
 
-// This helper function does a linear interpolation of a value from
-// one range to another. This can be very useful for converting the
-// motion of a Spring to a range of UI property values. For example a
-// spring moving from position 0 to 1 could be interpolated to move a
-// view from pixel 300 to 350 and scale it from 0.5 to 1. The current
-// position of the `Spring` just needs to be run through this method
-// taking its input range in the _from_ parameters with the property
-// animation range in the _to_ parameters.
+/**
+ * This helper function does a linear interpolation of a value from
+ * one range to another. This can be very useful for converting the
+ * motion of a Spring to a range of UI property values. For example a
+ * spring moving from position 0 to 1 could be interpolated to move a
+ * view from pixel 300 to 350 and scale it from 0.5 to 1. The current
+ * position of the `Spring` just needs to be run through this method
+ * taking its input range in the _from_ parameters with the property
+ * animation range in the _to_ parameters.
+ * @public
+ */
 export function mapValueInRange(
   value: number,
   fromLow: number,
@@ -32,9 +35,15 @@ export function mapValueInRange(
   return toLow + valueScale * toRangeSize;
 }
 
-// Interpolate two hex colors in a 0 - 1 range or optionally provide a
-// custom range with fromLow,fromHight. The output will be in hex by default
-// unless asRGB is true in which case it will be returned as an rgb string.
+/**
+ * Interpolate two hex colors in a 0 - 1 range or optionally provide a
+ * custom range with fromLow,fromHight. The output will be in hex by default
+ * unless asRGB is true in which case it will be returned as an rgb string.
+ *
+ * @public
+ * @param asRGB Return an rgb-style string
+ * @return A string in hex color format unless asRGB is true, in which case a string in rgb format
+ */
 export function interpolateColor(
   val: number,
   startColorStr: string,

--- a/src/MathUtil.js
+++ b/src/MathUtil.js
@@ -41,7 +41,7 @@ export function mapValueInRange(
  * unless asRGB is true in which case it will be returned as an rgb string.
  *
  * @public
- * @param asRGB Return an rgb-style string
+ * @param asRGB Whether to return an rgb-style string
  * @return A string in hex color format unless asRGB is true, in which case a string in rgb format
  */
 export function interpolateColor(

--- a/src/OrigamiValueConverter.js
+++ b/src/OrigamiValueConverter.js
@@ -14,6 +14,7 @@
 // [Rebound](http://facebook.github.io/rebound).
 // You mostly don't need to worry about this, just use
 // SpringConfig.fromOrigamiTensionAndFriction(v, v);
+
 export function tensionFromOrigamiValue(oValue: number): number {
   return (oValue - 30.0) * 3.62 + 194.0;
 }

--- a/src/PhysicsState.js
+++ b/src/PhysicsState.js
@@ -9,12 +9,11 @@
  * @flow
  */
 
-// PhysicsState
-// ------------
-// **PhysicsState** consists of a position and velocity. A Spring uses
-// this internally to keep track of its current and prior position and
-// velocity values.
-
+/**
+ * Consists of a position and velocity. A Spring uses
+ * this internally to keep track of its current and prior position and
+ * velocity values.
+ */
 class PhysicsState {
   position: number = 0;
   velocity: number = 0;

--- a/src/Spring.js
+++ b/src/Spring.js
@@ -16,20 +16,21 @@ import type {SpringListener} from './types';
 import PhysicsState from './PhysicsState';
 import {removeFirst} from './util';
 
-// Spring
-// ------
-// **Spring** provides a model of a classical spring acting to
-// resolve a body to equilibrium. Springs have configurable
-// tension which is a force multipler on the displacement of the
-// spring from its rest point or `endValue` as defined by [Hooke's
-// law](http://en.wikipedia.org/wiki/Hooke's_law). Springs also have
-// configurable friction, which ensures that they do not oscillate
-// infinitely. When a Spring is displaced by updating it's resting
-// or `currentValue`, the SpringSystems that contain that Spring
-// will automatically start looping to solve for equilibrium. As each
-// timestep passes, `SpringListener` objects attached to the Spring
-// will be notified of the updates providing a way to drive an
-// animation off of the spring's resolution curve.
+/**
+ * Provides a model of a classical spring acting to
+ * resolve a body to equilibrium. Springs have configurable
+ * tension which is a force multipler on the displacement of the
+ * spring from its rest point or `endValue` as defined by [Hooke's
+ * law](http://en.wikipedia.org/wiki/Hooke's_law). Springs also have
+ * configurable friction, which ensures that they do not oscillate
+ * infinitely. When a Spring is displaced by updating it's resting
+ * or `currentValue`, the SpringSystems that contain that Spring
+ * will automatically start looping to solve for equilibrium. As each
+ * timestep passes, `SpringListener` objects attached to the Spring
+ * will be notified of the updates providing a way to drive an
+ * animation off of the spring's resolution curve.
+ * @public
+ */
 class Spring {
   static _ID: number = 0;
   static MAX_DELTA_TIME_SEC: number = 0.064;
@@ -55,58 +56,73 @@ class Spring {
     this._springSystem = springSystem;
   }
 
-  // Remove a Spring from simulation and clear its listeners.
-  destroy() {
+  /**
+   * Remove a Spring from simulation and clear its listeners.
+   * @public
+   */
+  destroy(): void {
     this.listeners = [];
     this._springSystem.deregisterSpring(this);
   }
 
-  // Get the id of the spring, which can be used to retrieve it from
-  // the SpringSystems it participates in later.
+  /**
+   * Get the id of the spring, which can be used to retrieve it from
+   * the SpringSystems it participates in later.
+   * @public
+   */
   getId(): string {
     return this._id;
   }
 
-  // Set the configuration values for this Spring. A SpringConfig
-  // contains the tension and friction values used to solve for the
-  // equilibrium of the Spring in the physics loop.
+  /**
+   * Set the configuration values for this Spring. A SpringConfig
+   * contains the tension and friction values used to solve for the
+   * equilibrium of the Spring in the physics loop.
+   * @public
+   */
   setSpringConfig(springConfig: SpringConfig) {
     this._springConfig = springConfig;
     return this;
   }
 
-  // Retrieve the SpringConfig used by this Spring.
+  /**
+   * Retrieve the SpringConfig used by this Spring.
+   * @public
+   */
   getSpringConfig(): SpringConfig {
     return this._springConfig;
   }
 
-  // Set the current position of this Spring. Listeners will be updated
-  // with this value immediately. If the rest or `endValue` is not
-  // updated to match this value, then the spring will be dispalced and
-  // the SpringSystem will start to loop to restore the spring to the
-  // `endValue`.
-  //
-  // A common pattern is to move a Spring around without animation by
-  // calling.
-  //
-  // ```
-  // spring.setCurrentValue(n).setAtRest();
-  // ```
-  //
-  // This moves the Spring to a new position `n`, sets the endValue
-  // to `n`, and removes any velocity from the `Spring`. By doing
-  // this you can allow the `SpringListener` to manage the position
-  // of UI elements attached to the spring even when moving without
-  // animation. For example, when dragging an element you can
-  // update the position of an attached view through a spring
-  // by calling `spring.setCurrentValue(x)`. When
-  // the gesture ends you can update the Springs
-  // velocity and endValue
-  // `spring.setVelocity(gestureEndVelocity).setEndValue(flingTarget)`
-  // to cause it to naturally animate the UI element to the resting
-  // position taking into account existing velocity. The codepaths for
-  // synchronous movement and spring driven animation can
-  // be unified using this technique.
+  /**
+   * Set the current position of this Spring. Listeners will be updated
+   * with this value immediately. If the rest or `endValue` is not
+   * updated to match this value, then the spring will be dispalced and
+   * the SpringSystem will start to loop to restore the spring to the
+   * `endValue`.
+   *
+   * A common pattern is to move a Spring around without animation by
+   * calling.
+   *
+   * ```
+   * spring.setCurrentValue(n).setAtRest();
+   * ```
+   *
+   * This moves the Spring to a new position `n`, sets the endValue
+   * to `n`, and removes any velocity from the `Spring`. By doing
+   * this you can allow the `SpringListener` to manage the position
+   * of UI elements attached to the spring even when moving without
+   * animation. For example, when dragging an element you can
+   * update the position of an attached view through a spring
+   * by calling `spring.setCurrentValue(x)`. When
+   * the gesture ends you can update the Springs
+   * velocity and endValue
+   * `spring.setVelocity(gestureEndVelocity).setEndValue(flingTarget)`
+   * to cause it to naturally animate the UI element to the resting
+   * position taking into account existing velocity. The codepaths for
+   * synchronous movement and spring driven animation can
+   * be unified using this technique.
+   * @public
+   */
   setCurrentValue(currentValue: number, skipSetAtRest: boolean) {
     this._startValue = currentValue;
     this._currentState.position = currentValue;
@@ -117,20 +133,29 @@ class Spring {
     return this;
   }
 
-  // Get the position that the most recent animation started at. This
-  // can be useful for determining the number off oscillations that
-  // have occurred.
+  /**
+   * Get the position that the most recent animation started at. This
+   * can be useful for determining the number off oscillations that
+   * have occurred.
+   * @public
+   */
   getStartValue(): number {
     return this._startValue;
   }
 
-  // Retrieve the current value of the Spring.
+  /**
+   * Retrieve the current value of the Spring.
+   * @public
+   */
   getCurrentValue(): number {
     return this._currentState.position;
   }
 
-  // Get the absolute distance of the Spring from it's resting endValue
-  // position.
+  /**
+   * Get the absolute distance of the Spring from it's resting endValue
+   * position.
+   * @public
+   */
   getCurrentDisplacementDistance(): number {
     return this.getDisplacementDistanceForState(this._currentState);
   }
@@ -139,12 +164,15 @@ class Spring {
     return Math.abs(this._endValue - state.position);
   }
 
-  // Set the endValue or resting position of the spring. If this
-  // value is different than the current value, the SpringSystem will
-  // be notified and will begin running its solver loop to resolve
-  // the Spring to equilibrium. Any listeners that are registered
-  // for onSpringEndStateChange will also be notified of this update
-  // immediately.
+  /**
+   * Set the endValue or resting position of the spring. If this
+   * value is different than the current value, the SpringSystem will
+   * be notified and will begin running its solver loop to resolve
+   * the Spring to equilibrium. Any listeners that are registered
+   * for onSpringEndStateChange will also be notified of this update
+   * immediately.
+   * @public
+   */
   setEndValue(endValue: number): this {
     if (this._endValue === endValue && this.isAtRest()) {
       return this;
@@ -160,18 +188,24 @@ class Spring {
     return this;
   }
 
-  // Retrieve the endValue or resting position of this spring.
+  /**
+   * Retrieve the endValue or resting position of this spring.
+   * @public
+   */
   getEndValue(): number {
     return this._endValue;
   }
 
-  // Set the current velocity of the Spring, in pixels per second. As
-  // previously mentioned, this can be useful when you are performing
-  // a direct manipulation gesture. When a UI element is released you
-  // may call setVelocity on its animation Spring so that the Spring
-  // continues with the same velocity as the gesture ended with. The
-  // friction, tension, and displacement of the Spring will then
-  // govern its motion to return to rest on a natural feeling curve.
+  /**
+   * Set the current velocity of the Spring, in pixels per second. As
+   * previously mentioned, this can be useful when you are performing
+   * a direct manipulation gesture. When a UI element is released you
+   * may call setVelocity on its animation Spring so that the Spring
+   * continues with the same velocity as the gesture ended with. The
+   * friction, tension, and displacement of the Spring will then
+   * govern its motion to return to rest on a natural feeling curve.
+   * @public
+   */
   setVelocity(velocity: number): this {
     if (velocity === this._currentState.velocity) {
       return this;
@@ -181,53 +215,77 @@ class Spring {
     return this;
   }
 
-  // Get the current velocity of the Spring, in pixels per second.
+  /**
+   * Get the current velocity of the Spring, in pixels per second.
+   * @public
+   */
   getVelocity(): number {
     return this._currentState.velocity;
   }
 
-  // Set a threshold value for the movement speed of the Spring below
-  // which it will be considered to be not moving or resting.
+  /**
+   * Set a threshold value for the movement speed of the Spring below
+   * which it will be considered to be not moving or resting.
+   * @public
+   */
   setRestSpeedThreshold(restSpeedThreshold: number): this {
     this._restSpeedThreshold = restSpeedThreshold;
     return this;
   }
 
-  // Retrieve the rest speed threshold for this Spring.
+  /**
+   * Retrieve the rest speed threshold for this Spring.
+   * @public
+   */
   getRestSpeedThreshold(): number {
     return this._restSpeedThreshold;
   }
 
-  // Set a threshold value for displacement below which the Spring
-  // will be considered to be not displaced i.e. at its resting
-  // `endValue`.
+  /**
+   * Set a threshold value for displacement below which the Spring
+   * will be considered to be not displaced i.e. at its resting
+   * `endValue`.
+   * @public
+   */
   setRestDisplacementThreshold(displacementFromRestThreshold: number): void {
     this._displacementFromRestThreshold = displacementFromRestThreshold;
   }
 
-  // Retrieve the rest displacement threshold for this spring.
+  /**
+   * Retrieve the rest displacement threshold for this spring.
+   * @public
+   */
   getRestDisplacementThreshold(): number {
     return this._displacementFromRestThreshold;
   }
 
-  // Enable overshoot clamping. This means that the Spring will stop
-  // immediately when it reaches its resting position regardless of
-  // any existing momentum it may have. This can be useful for certain
-  // types of animations that should not oscillate such as a scale
-  // down to 0 or alpha fade.
+  /**
+   * Enable overshoot clamping. This means that the Spring will stop
+   * immediately when it reaches its resting position regardless of
+   * any existing momentum it may have. This can be useful for certain
+   * types of animations that should not oscillate such as a scale
+   * down to 0 or alpha fade.
+   * @public
+   */
   setOvershootClampingEnabled(enabled: boolean): this {
     this._overshootClampingEnabled = enabled;
     return this;
   }
 
-  // Check if overshoot clamping is enabled for this spring.
+  /**
+   * Check if overshoot clamping is enabled for this spring.
+   * @public
+   */
   isOvershootClampingEnabled(): boolean {
     return this._overshootClampingEnabled;
   }
 
-  // Check if the Spring has gone past its end point by comparing
-  // the direction it was moving in when it started to the current
-  // position and end value.
+  /**
+   * Check if the Spring has gone past its end point by comparing
+   * the direction it was moving in when it started to the current
+   * position and end value.
+   * @public
+   */
   isOvershooting(): boolean {
     const start = this._startValue;
     const end = this._endValue;
@@ -238,11 +296,14 @@ class Spring {
     );
   }
 
-  // Spring.advance is the main solver method for the Spring. It takes
-  // the current time and delta since the last time step and performs
-  // an RK4 integration to get the new position and velocity state
-  // for the Spring based on the tension, friction, velocity, and
-  // displacement of the Spring.
+  /**
+   * The main solver method for the Spring. It takes
+   * the current time and delta since the last time step and performs
+   * an RK4 integration to get the new position and velocity state
+   * for the Spring based on the tension, friction, velocity, and
+   * displacement of the Spring.
+   * @public
+   */
   advance(time: number, realDeltaTime: number): void {
     let isAtRest = this.isAtRest();
 
@@ -374,10 +435,13 @@ class Spring {
     }
   }
 
-  // Check if the SpringSystem should advance. Springs are advanced
-  // a final frame after they reach equilibrium to ensure that the
-  // currentValue is exactly the requested endValue regardless of the
-  // displacement threshold.
+  /**
+   * Check if the SpringSystem should advance. Springs are advanced
+   * a final frame after they reach equilibrium to ensure that the
+   * currentValue is exactly the requested endValue regardless of the
+   * displacement threshold.
+   * @public
+   */
   systemShouldAdvance(): boolean {
     return !this.isAtRest() || !this.wasAtRest();
   }
@@ -386,12 +450,15 @@ class Spring {
     return this._wasAtRest;
   }
 
-  // Check if the Spring is atRest meaning that it's currentValue and
-  // endValue are the same and that it has no velocity. The previously
-  // described thresholds for speed and displacement define the bounds
-  // of this equivalence check. If the Spring has 0 tension, then it will
-  // be considered at rest whenever its absolute velocity drops below the
-  // restSpeedThreshold.
+  /**
+   * Check if the Spring is atRest meaning that it's currentValue and
+   * endValue are the same and that it has no velocity. The previously
+   * described thresholds for speed and displacement define the bounds
+   * of this equivalence check. If the Spring has 0 tension, then it will
+   * be considered at rest whenever its absolute velocity drops below the
+   * restSpeedThreshold.
+   * @public
+   */
   isAtRest(): boolean {
     return (
       Math.abs(this._currentState.velocity) < this._restSpeedThreshold &&
@@ -401,10 +468,13 @@ class Spring {
     );
   }
 
-  // Force the spring to be at rest at its current position. As
-  // described in the documentation for setCurrentValue, this method
-  // makes it easy to do synchronous non-animated updates to ui
-  // elements that are attached to springs via SpringListeners.
+  /**
+   * Force the spring to be at rest at its current position. As
+   * described in the documentation for setCurrentValue, this method
+   * makes it easy to do synchronous non-animated updates to ui
+   * elements that are attached to springs via SpringListeners.
+   * @public
+   */
   setAtRest(): this {
     this._endValue = this._currentState.position;
     this._tempState.position = this._currentState.position;

--- a/src/Spring.js
+++ b/src/Spring.js
@@ -152,7 +152,7 @@ class Spring {
   }
 
   /**
-   * Get the absolute distance of the Spring from it's resting endValue
+   * Get the absolute distance of the Spring from its resting endValue
    * position.
    * @public
    */
@@ -160,6 +160,9 @@ class Spring {
     return this.getDisplacementDistanceForState(this._currentState);
   }
 
+  /**
+   * Get the absolute distance of the Spring from a given state value
+   */
   getDisplacementDistanceForState(state: PhysicsState) {
     return Math.abs(this._endValue - state.position);
   }

--- a/src/SpringConfig.js
+++ b/src/SpringConfig.js
@@ -12,12 +12,13 @@
 import * as OrigamiValueConverter from './OrigamiValueConverter';
 import BouncyConversion from './BouncyConversion';
 
-// SpringConfig
-// ------------
-// **SpringConfig** maintains a set of tension and friction constants
-// for a Spring. You can use fromOrigamiTensionAndFriction to convert
-// values from the [Origami](http://facebook.github.io/origami/)
-// design tool directly to Rebound spring constants.
+/**
+ * Maintains a set of tension and friction constants
+ * for a Spring. You can use fromOrigamiTensionAndFriction to convert
+ * values from the [Origami](http://facebook.github.io/origami/)
+ * design tool directly to Rebound spring constants.
+ * @public
+ */
 class SpringConfig {
   friction: number;
   tension: number;
@@ -27,10 +28,13 @@ class SpringConfig {
     7,
   );
 
-  // Convert an origami Spring tension and friction to Rebound spring
-  // constants. If you are prototyping a design with Origami, this
-  // makes it easy to make your springs behave exactly the same in
-  // Rebound.
+  /**
+   * Convert an origami Spring tension and friction to Rebound spring
+   * constants. If you are prototyping a design with Origami, this
+   * makes it easy to make your springs behave exactly the same in
+   * Rebound.
+   * @public
+   */
   static fromOrigamiTensionAndFriction(
     tension: number,
     friction: number,
@@ -41,9 +45,12 @@ class SpringConfig {
     );
   }
 
-  // Convert an origami PopAnimation Spring bounciness and speed to Rebound
-  // spring constants. If you are using PopAnimation patches in Origami, this
-  // utility will provide springs that match your prototype.
+  /**
+   * Convert an origami PopAnimation Spring bounciness and speed to Rebound
+   * spring constants. If you are using PopAnimation patches in Origami, this
+   * utility will provide springs that match your prototype.
+   * @public
+   */
   static fromBouncinessAndSpeed(
     bounciness: number,
     speed: number,
@@ -55,8 +62,11 @@ class SpringConfig {
     );
   }
 
-  // Create a SpringConfig with no tension or a coasting spring with some
-  // amount of Friction so that it does not coast infininitely.
+  /**
+   * Create a SpringConfig with no tension or a coasting spring with some
+   * amount of Friction so that it does not coast infininitely.
+   * @public
+   */
   static coastingConfigWithOrigamiFriction(friction: number): SpringConfig {
     return new SpringConfig(
       0,

--- a/src/util.js
+++ b/src/util.js
@@ -53,10 +53,14 @@ type Color = {
   b: number,
 };
 
-// Here are a couple of function to convert colors between hex codes and RGB
-// component values. These are handy when performing color
-// tweening animations.
 const colorCache = {};
+/**
+ * Converts a hex-formatted color string to its rgb-formatted equivalent. Handy
+ * when performing color tweening animations
+ * @public
+ * @param colorString A hex-formatted color string
+ * @return An rgb-formatted color string
+ */
 export function hexToRGB(colorString: string): Color {
   if (colorCache[colorString]) {
     return colorCache[colorString];
@@ -86,6 +90,13 @@ export function hexToRGB(colorString: string): Color {
   return ret;
 }
 
+/**
+ * Converts a rgb-formatted color string to its hex-formatted equivalent. Handy
+ * when performing color tweening animations
+ * @public
+ * @param colorString An rgb-formatted color string
+ * @return A hex-formatted color string
+ */
 export function rgbToHex(rNum: number, gNum: number, bNum: number): string {
   let r = rNum.toString(16);
   let g = gNum.toString(16);


### PR DESCRIPTION
This begins the process of transforming existing documentation-style
comments to the JSDoc format. Mark each as being public (@public) so
that a future generation process can export only public API.

- [x] Spring
- [x] SpringConfig
- [x] SpringSystem
- [x] Loopers
- [x] MathUtil
- [x] util
- [x] BouncyConversion?
- [x] OrigamiValueConverter
- [x] PhysicsState

For context, I'm working on a Docusaurus-built version of the
documentation and examples in a single site. Generating docs from these
will be part of that build process.