### PR TITLE
[AnimationLooper] Use performance.now()'s high resolution time

### DIFF
--- a/src/Loopers.js
+++ b/src/Loopers.js
@@ -10,7 +10,7 @@
  */
 
 import type SpringSystem from './SpringSystem';
-import * as util from './util';
+import {onFrame, performanceNow} from './util';
 
 /**
  * Plays each frame of the SpringSystem on animation
@@ -24,8 +24,8 @@ export class AnimationLooper {
   run() {
     const springSystem = getSpringSystem.call(this);
 
-    util.onFrame(() => {
-      springSystem.loop(Date.now());
+    onFrame(() => {
+      springSystem.loop(performanceNow());
     });
   }
 }

--- a/src/util.js
+++ b/src/util.js
@@ -41,6 +41,12 @@ export function onFrame(func: Function) {
   return _onFrame(func);
 }
 
+const start = Date.now();
+export const performanceNow =
+  typeof performance === 'object' && typeof performance.now === 'function'
+    ? () => performance.now()
+    : () => Date.now() - start;
+
 // Lop off the first occurence of the reference in the Array.
 export function removeFirst<T>(array: Array<T>, item: T): void {
   const idx = array.indexOf(item);


### PR DESCRIPTION
This uses performance.now (or a fallback to Date.now in environments without it) to provide a more accurate measurement of time while animating, which should result in smoother animations.

Deliberately use this rather than using `requestAnimationFrame`'s callback's argument as it can sometimes misrepresent the current time.  [See its use in velocity](https://github.com/julianshapiro/velocity/blob/92f6981723e51895855812366739a04fef93176b/src/Velocity/tick.ts#L158-L160).

Supercedes #22.