### PR TITLE
Make Spring setters consistently return this

### DIFF
--- a/src/Spring.js
+++ b/src/Spring.js
@@ -81,7 +81,7 @@ class Spring {
    * equilibrium of the Spring in the physics loop.
    * @public
    */
-  setSpringConfig(springConfig: SpringConfig) {
+  setSpringConfig(springConfig: SpringConfig): this {
     this._springConfig = springConfig;
     return this;
   }
@@ -124,7 +124,7 @@ class Spring {
    * be unified using this technique.
    * @public
    */
-  setCurrentValue(currentValue: number, skipSetAtRest: boolean) {
+  setCurrentValue(currentValue: number, skipSetAtRest: boolean): this {
     this._startValue = currentValue;
     this._currentState.position = currentValue;
     if (!skipSetAtRest) {
@@ -251,8 +251,9 @@ class Spring {
    * `endValue`.
    * @public
    */
-  setRestDisplacementThreshold(displacementFromRestThreshold: number): void {
+  setRestDisplacementThreshold(displacementFromRestThreshold: number): this {
     this._displacementFromRestThreshold = displacementFromRestThreshold;
+    return this;
   }
 
   /**


### PR DESCRIPTION
Currently, all setters in a `Spring` return `this`, other than `Spring#setRestDisplacementThreshold` which returns `undefined`. This disallows it from being chained with other setters.

Additionally, `Spring#setSpringConfig` and `Spring#setCurrentValue` both return `this` but are not typed as such.

This pull request resolves both of these issues.